### PR TITLE
Raise the child exception on the parent (fixes #1)

### DIFF
--- a/lib/fork_break.rb
+++ b/lib/fork_break.rb
@@ -45,6 +45,8 @@ module ForkBreak
           raise BreakpointNotReachedError.new("Never reached breakpoint #{@next_breakpoint.inspect}")
         end
       end
+    rescue EOFError => exception
+      raise @fork.exception || exception
     end
 
     def finish
@@ -65,6 +67,8 @@ module ForkBreak
         @next_breakpoint = @fork.receive_object unless symbol == :forkbreak_end
         puts "#{@fork.pid} received #{@next_breakpoint}" if @debug
       end
+    rescue EOFError => exception
+      raise @fork.exception || exception
     end
   end
 end

--- a/spec/fork_break_spec.rb
+++ b/spec/fork_break_spec.rb
@@ -90,5 +90,15 @@ module ForkBreak
         counter_after_synced_execution(counter_path, with_lock = false).should == 1
       end
     end
+
+    it "raises the process exception" do
+      class MyException < StandardError; end
+
+      process = ForkBreak::Process.new do
+        raise MyException
+      end
+
+      expect { process.finish.wait }.to raise_error(MyException)
+    end
   end
 end


### PR DESCRIPTION
Hi,
Upon investigation on the fork gem I found a way to raise the child exception on the parent.
