### PR TITLE
Ignore breakpoints when running outside a ForkBreak process (fixes #13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ puts counter_after_synced_execution("counter_with_lock",    true)  # => 2
 puts counter_after_synced_execution("counter_without_lock", false) # => 1
 ```
 
+When running outside a ForkBreak process the breakpoints will be ignored so that you can use the same classes with
+breakpoints in production code.
+
 There's also the possibility of adding a predefined timeout to the wait function and having it raise an exception.
 
 ```ruby

--- a/lib/fork_break.rb
+++ b/lib/fork_break.rb
@@ -1,4 +1,5 @@
 require 'fork'
+require 'fork_break/null_breakpoint_setter'
 require 'fork_break/breakpoint_setter'
 require 'fork_break/breakpoints'
 require 'fork_break/process'

--- a/lib/fork_break/null_breakpoint_setter.rb
+++ b/lib/fork_break/null_breakpoint_setter.rb
@@ -1,0 +1,7 @@
+module ForkBreak
+  class NullBreakpointSetter
+    def <<(*)
+      # no-op
+    end
+  end
+end

--- a/lib/fork_break/process.rb
+++ b/lib/fork_break/process.rb
@@ -4,6 +4,8 @@ module ForkBreak
       attr_accessor :breakpoint_setter
     end
 
+    @breakpoint_setter = NullBreakpointSetter.new
+
     def initialize(debug = false, &block)
       @debug = debug
       @fork = Fork.new(:return, :to_fork, :from_fork) do |child_fork|

--- a/spec/fork_break_spec.rb
+++ b/spec/fork_break_spec.rb
@@ -86,6 +86,21 @@ describe ForkBreak::Process do
     end
   end
 
+  it 'ignores breakpoints when running outside a ForkBreak process' do
+    class Foo
+      include ForkBreak::Breakpoints
+
+      def bar
+        breakpoints << :test
+        'baz'
+      end
+    end
+
+    expect(Foo.new.breakpoints).to be_kind_of(ForkBreak::NullBreakpointSetter)
+    expect { Foo.new.bar }.to_not raise_error
+    expect(Foo.new.bar).to eq('baz')
+  end
+
   it 'raises the process exception' do
     class MyException < StandardError; end
 


### PR DESCRIPTION
This fixes a `NoMethodError: undefined method `<<' for nil:NilClass` when running outside a ForkBreak process.

@vemv do you want to take a look?
