### PR TITLE
Keep return value of the forked process in the ForkBreak process (fixes #15)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,3 +19,9 @@ Metrics/AbcSize:
 
 Metrics/MethodLength:
   Max: 15
+
+Metrics/CyclomaticComplexity:
+  Max: 7
+
+Metrics/PerceivedComplexity:
+  Max: 8

--- a/spec/fork_break_spec.rb
+++ b/spec/fork_break_spec.rb
@@ -118,4 +118,18 @@ describe ForkBreak::Process do
 
     expect { process.finish.wait(timeout: 0.01) }.to raise_error(ForkBreak::WaitTimeout)
   end
+
+  it 'keeps the return value of the process' do
+    class Foo
+      include ForkBreak::Breakpoints
+
+      def bar
+        'baz'
+      end
+    end
+
+    process = ForkBreak::Process.new { Foo.new.bar }.finish.wait
+
+    expect(process.return_value).to eq('baz')
+  end
 end


### PR DESCRIPTION
Maintain the return value of the forked process in the ForkBreak process to improve debugging

@vemv want to take a look?